### PR TITLE
ruby-install needs to be at v0.4.3 in order to install Ruby 2.1.2.

### DIFF
--- a/recipes/_ruby.rb
+++ b/recipes/_ruby.rb
@@ -34,11 +34,11 @@ unless windows?
   # Install ruby-install so we can easily install and manage rubies. This is
   # needed by the +ruby_install+ HWRP which installs rubies for us.
   remote_install 'ruby-install' do
-    source 'https://codeload.github.com/postmodern/ruby-install/tar.gz/v0.4.1'
-    checksum '1b35d2b6dbc1e75f03fff4e8521cab72a51ad67e32afd135ddc4532f443b730e'
-    version '0.4.1'
+    source 'https://codeload.github.com/postmodern/ruby-install/tar.gz/v0.4.3'
+    checksum '0ec8c23699aad534dcab549c0f6543e066725a62f5b3d7e8dae311c61df1aef3'
+    version '0.4.3'
     install_command "make -j #{node.builders} install"
-    not_if { installed_at_version?('ruby-install', '0.4.1') }
+    not_if { installed_at_version?('ruby-install', '0.4.3') }
   end
 end
 

--- a/spec/recipes/ruby_spec.rb
+++ b/spec/recipes/ruby_spec.rb
@@ -48,9 +48,9 @@ describe 'omnibus::_ruby' do
       allow_any_instance_of(Chef::Resource).to receive(:installed_at_version?)
 
       expect(chef_run).to install_remote_install('ruby-install')
-        .with_source('https://codeload.github.com/postmodern/ruby-install/tar.gz/v0.4.1')
-        .with_checksum('1b35d2b6dbc1e75f03fff4e8521cab72a51ad67e32afd135ddc4532f443b730e')
-        .with_version('0.4.1')
+        .with_source('https://codeload.github.com/postmodern/ruby-install/tar.gz/v0.4.3')
+        .with_checksum('0ec8c23699aad534dcab549c0f6543e066725a62f5b3d7e8dae311c61df1aef3')
+        .with_version('0.4.3')
         .with_install_command('make -j 2 install')
     end
 


### PR DESCRIPTION
I have no idea how 9ca8d9afdc3f6a06dcefda330e3731e79675d9d7 ever worked... or if it did. But according to the [ruby-install Changelog](https://github.com/postmodern/ruby-install/blob/master/ChangeLog.md) you need at least v0.4.3 of ruby-install to get Ruby 2.1.2

/cc @atomic-penguin 