### PR TITLE
Use https for ccache.

### DIFF
--- a/recipes/_ccache.rb
+++ b/recipes/_ccache.rb
@@ -27,7 +27,7 @@ include_recipe 'omnibus::_compile'
 
 # Set up ccache, to speed up subsequent compilations.
 remote_install 'ccache' do
-  source 'http://samba.org/ftp/ccache/ccache-3.1.9.tar.gz'
+  source 'https://samba.org/ftp/ccache/ccache-3.1.9.tar.gz'
   version '3.1.9'
   checksum 'a2270654537e4b736e437975e0cb99871de0975164a509dee34cf91e36eeb447'
   build_command './configure'

--- a/spec/recipes/ccache_spec.rb
+++ b/spec/recipes/ccache_spec.rb
@@ -13,7 +13,7 @@ describe 'omnibus::_ccache' do
 
   it 'remote_installs ccache' do
     expect(chef_run).to install_remote_install('ccache')
-      .with_source('http://samba.org/ftp/ccache/ccache-3.1.9.tar.gz')
+      .with_source('https://samba.org/ftp/ccache/ccache-3.1.9.tar.gz')
       .with_version('3.1.9')
       .with_checksum('a2270654537e4b736e437975e0cb99871de0975164a509dee34cf91e36eeb447')
       .with_build_command('./configure')


### PR DESCRIPTION
Looks like samba.org may have changed the way it handles https. Chef seems to not handle it gracefully.

```ruby
remote_file[download[ccache-3.1.9]] (dynamically defined) had an error: OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 state=SSLv2/v3 read server hello A: unknown protocol
```

This seems to fix it nicely.