### PR TITLE
EL 7 build requirements

### DIFF
--- a/recipes/_packaging.rb
+++ b/recipes/_packaging.rb
@@ -37,6 +37,8 @@ elsif rhel?
   package 'ncurses-devel'
   package 'rpm-build'
   package 'zlib-devel'
+  # EL 7 split rpm-sign into its own package:  http://cholla.mmto.org/computers/linux/rpm/signing.html
+  package 'rpm-sign' if node['platform_version'].satisfies?('>= 7')
 
   # This script makes unattended rpm signing possible!
   cookbook_file ::File.join(build_user_home, 'sign-rpm') do


### PR DESCRIPTION
Adding to this branch as we run across changes needed to build omnibus packages on el7:
* Package signing on EL7 requires the rpm-sign package.

cc @opscode-cookbooks/ociv @mattray @kaustubh-d