### PR TITLE
Don’t configure `SSL_CERT_FILE` globally on Windows

### DIFF
--- a/libraries/ruby_install.rb
+++ b/libraries/ruby_install.rb
@@ -201,12 +201,6 @@ class Chef
       cacerts.source(cacerts_url)
       cacerts.backup(false)
       cacerts.run_action(:create)
-
-      ENV['SSL_CERT_FILE'] = cacert_file
-
-      ssl_env = Resource::Env.new('SSL_CERT_FILE', run_context)
-      ssl_env.value(cacert_file)
-      ssl_env.run_action(:create)
     end
 
     # Check if the given Ruby is installed by directory.


### PR DESCRIPTION
This can cause issues in the CCR when Chef’s underlying `ssl_verify_mode` config option is set to `:verify_peer` which is the default for Chef 12+.

/cc @opscode-cookbooks/ociv @jdmundrawala @adamedx 