### PR TITLE
[ruby-windows] install a cacerts bundle that works with the S3 root cert

### DIFF
--- a/libraries/ruby_install.rb
+++ b/libraries/ruby_install.rb
@@ -145,7 +145,7 @@ class Chef
     end
 
     def cacerts_url
-      'http://curl.haxx.se/ca/cacert.pem'
+      'https://opscode-omnibus-cache.s3.amazonaws.com/cacerts-2014.08.20-c9f4f7f4d6a5ef6633e893577a09865e'
     end
 
     def cacerts_download_path


### PR DESCRIPTION
See the following for more info:

https://github.com/opscode/chef-dk/issues/199
https://blog.mozilla.org/security/2014/09/08/phasing-out-certificates-with-1024-bit-rsa-keys/
https://forums.aws.amazon.com/thread.jspa?threadID=164095
https://github.com/opscode/omnibus-supermarket/commit/89197026af2931de82cfdc13d92ca2230cced3b6

/cc @opscode-cookbooks/ociv