### PR TITLE
Use samba mirror for ccache and rsync packages

### DIFF
--- a/recipes/_ccache.rb
+++ b/recipes/_ccache.rb
@@ -29,7 +29,7 @@ include_recipe 'omnibus::_compile'
 
 # Set up ccache, to speed up subsequent compilations.
 remote_install 'ccache' do
-  source 'ftp://ftp.netbsd.org/pub/pkgsrc/distfiles/ccache-3.1.9.tar.gz'
+  source 'https://www.samba.org/ftp/ccache/ccache-3.1.9.tar.gz'
   version '3.1.9'
   checksum 'a2270654537e4b736e437975e0cb99871de0975164a509dee34cf91e36eeb447'
   build_command './configure'

--- a/recipes/_rsync.rb
+++ b/recipes/_rsync.rb
@@ -32,7 +32,7 @@ return if omnibus_toolchain_enabled?
 include_recipe 'omnibus::_compile'
 
 remote_install 'rsync' do
-  source 'ftp://ftp.netbsd.org/pub/pkgsrc/distfiles/rsync-3.1.0.tar.gz'
+  source 'http://rsync.samba.org/ftp/rsync/src/rsync-3.1.0.tar.gz'
   version '3.1.0'
   checksum '81ca23f77fc9b957eb9845a6024f41af0ff0c619b7f38576887c63fa38e2394e'
   build_command './configure'

--- a/spec/recipes/ccache_spec.rb
+++ b/spec/recipes/ccache_spec.rb
@@ -13,7 +13,7 @@ describe 'omnibus::_ccache' do
 
   it 'remote_installs ccache' do
     expect(chef_run).to install_remote_install('ccache')
-      .with_source('ftp://ftp.netbsd.org/pub/pkgsrc/distfiles/ccache-3.1.9.tar.gz')
+      .with_source('https://www.samba.org/ftp/ccache/ccache-3.1.9.tar.gz')
       .with_version('3.1.9')
       .with_checksum('a2270654537e4b736e437975e0cb99871de0975164a509dee34cf91e36eeb447')
       .with_build_command('./configure')

--- a/spec/recipes/rsync_spec.rb
+++ b/spec/recipes/rsync_spec.rb
@@ -11,7 +11,7 @@ describe 'omnibus::_rsync' do
     allow_any_instance_of(Chef::Resource).to receive(:installed_at_version?)
 
     expect(chef_run).to install_remote_install('rsync')
-      .with_source('ftp://ftp.netbsd.org/pub/pkgsrc/distfiles/rsync-3.1.0.tar.gz')
+      .with_source('http://rsync.samba.org/ftp/rsync/src/rsync-3.1.0.tar.gz')
       .with_version('3.1.0')
       .with_checksum('81ca23f77fc9b957eb9845a6024f41af0ff0c619b7f38576887c63fa38e2394e')
       .with_build_command('./configure')


### PR DESCRIPTION
Reverts 4fc349c.  We already use the samba mirror for rsync in omnibus-software, and the currently specified mirror doesn't seem to be consistently more stable.

cc @opscode-cookbooks/ociv 