### PR TITLE
Install glibc-static on non-Power platforms running el-6 or higher.

### DIFF
--- a/recipes/_packaging.rb
+++ b/recipes/_packaging.rb
@@ -45,7 +45,12 @@ elsif rhel?
   package 'rpm-sign' if node['platform_version'].satisfies?('>= 7')
   # EL 6 and later consider glibc-static optional: https://access.redhat.com/solutions/33868
   # The libhugetlbfs build (analytics) requires it.
-  package 'glibc-static' if node['platform_version'].satisfies?('>= 6', '<= 7')
+  if ppc64? || ppc64le?
+    # See https://github.com/kaustubh-d/omnibus/commit/41b547817572a8a75d857cfc3562ca819f327761
+    package 'glibc-static' if node['platform_version'].satisfies?('~> 6')
+  else
+    package 'glibc-static' if node['platform_version'].satisfies?('>= 6')
+  end
 
   # This script makes unattended rpm signing possible!
   cookbook_file ::File.join(build_user_home, 'sign-rpm') do


### PR DESCRIPTION
@mattray @kaustubh-d Let me know if I've accurately reflected what needs to happen on Power.

@sersut @josephrdsmith This should get the analytics build past the libhugetlbfs break. (Tested manually here:  http://wilson.ci.chef.co/job/opscode-analytics-build/1398/architecture=x86_64,platform=el-7,project=opscode-analytics,role=builder/console)

cc @opscode-cookbooks/ociv 