### PR TITLE
Add path for 7-zip

### DIFF
--- a/recipes/_packaging.rb
+++ b/recipes/_packaging.rb
@@ -61,4 +61,7 @@ elsif windows?
 
   omnibus_env['PATH'] << node['wix']['home']
   omnibus_env['PATH'] << node['7-zip']['home']
+  # This works around 7-zip apparently not respecting its install dir, and installing to Program Files instead.
+  # Is there a helper for program files? 
+  omnibus_env['PATH'] << "c:/Program Files/7-zip"
 end

--- a/recipes/_packaging.rb
+++ b/recipes/_packaging.rb
@@ -62,6 +62,5 @@ elsif windows?
   omnibus_env['PATH'] << node['wix']['home']
   omnibus_env['PATH'] << node['7-zip']['home']
   # This works around 7-zip apparently not respecting its install dir, and installing to Program Files instead.
-  # Is there a helper for program files? 
-  omnibus_env['PATH'] << "c:/Program Files/7-zip"
+  omnibus_env['PATH'] << windows_safe_path_join(ENV['SYSTEMDRIVE'], 'Program Files', '7-zip')
 end


### PR DESCRIPTION
This is a workaround for a bug in either the 7-zip installer or the
cookbook.
Apparently 7-zip isn't respecting the install path on the command line,
and is installing itself to Program Files instead. But we set the path
to the directory we think it should be going in. Leaving the old
command in place just incase something fixes itself upstream.