### PR TITLE
Support OS X 10.11

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -33,7 +33,7 @@ platforms:
     run_list: apt::default
   - name: ubuntu-10.04
     run_list: apt::default
-  # Talk to the OCIV team if you need access to the Solaris development infra.
+  # Talk to the Engineering Services team if you need access to the Solaris development infra.
 <%
 {
   'solaris-11-i86pc' => {
@@ -73,7 +73,7 @@ platforms:
 <% end %>
   #
   # The following (private) boxes are shared via Atlas. Please note this
-  # requires adding your Atlans account to the `Chef` org and will
+  # requires adding your Atlas account to the `Chef` org and will
   # require a `vagrant login`.
   #
   # The Mac OS X boxes are VMware only also. You can enable VMware Fusion
@@ -89,6 +89,9 @@ platforms:
   - name: macosx-10.10
     driver:
       box: chef/macosx-10.10 # private
+  - name: macosx-10.11
+    driver:
+      box: chef/macosx-10.11 # private
   - name: windows-7-professional
     driver:
       box: chef/windows-7-professional # private

--- a/recipes/_bash.rb
+++ b/recipes/_bash.rb
@@ -38,10 +38,11 @@ end
 
 # Link /bin/bash to our bash, since some systems have their own bash, but we
 # will force our will on them!
-link '/bin/bash' do
-  to '/usr/local/bin/bash'
+unless mac_os_x? && node['platform_version'].satisfies?('>= 10.11')
+  link '/bin/bash' do
+    to '/usr/local/bin/bash'
+  end
 end
-
 #
 # Create an .bashrc.d-style directory for arbitrary loading.
 #

--- a/recipes/_bash.rb
+++ b/recipes/_bash.rb
@@ -36,13 +36,6 @@ remote_install 'bash' do
   not_if { installed_at_version?('/usr/local/bin/bash', '4.3.30') }
 end
 
-# Link /bin/bash to our bash, since some systems have their own bash, but we
-# will force our will on them!
-unless mac_os_x? && node['platform_version'].satisfies?('>= 10.11')
-  link '/bin/bash' do
-    to '/usr/local/bin/bash'
-  end
-end
 #
 # Create an .bashrc.d-style directory for arbitrary loading.
 #

--- a/recipes/_git.rb
+++ b/recipes/_git.rb
@@ -120,6 +120,7 @@ else
     package 'curl'
     package 'expat'
     package 'gettext'
+    git_environment['CPPFLAGS'] = '-I/usr/local/opt/openssl/include' if node['platform_version'].satisfies?('>= 10.11')
   elsif rhel?
     package 'curl-devel'
     package 'expat-devel'

--- a/recipes/_rsync.rb
+++ b/recipes/_rsync.rb
@@ -40,11 +40,3 @@ remote_install 'rsync' do
   install_command 'make install'
   not_if { installed_at_version?('/usr/local/bin/rsync', '3.1.0') }
 end
-
-# Link /bin/rsync to our rsync, since some systems have their own rsync, but we
-# will force our will on them!
-unless mac_os_x? && node['platform_version'].satisfies?('>= 10.11')
-  link '/bin/rsync' do
-    to '/usr/local/bin/rsync'
-  end
-end

--- a/recipes/_rsync.rb
+++ b/recipes/_rsync.rb
@@ -43,6 +43,8 @@ end
 
 # Link /bin/rsync to our rsync, since some systems have their own rsync, but we
 # will force our will on them!
-link '/bin/rsync' do
-  to '/usr/local/bin/rsync'
+unless mac_os_x? && node['platform_version'].satisfies?('>= 10.11')
+  link '/bin/rsync' do
+    to '/usr/local/bin/rsync'
+  end
 end

--- a/recipes/_user.rb
+++ b/recipes/_user.rb
@@ -40,11 +40,7 @@ user node['omnibus']['build_user'] do
   supports manage_home: true
   password node['omnibus']['build_user_password']
   unless windows?
-    if mac_os_x? && node['platform_version'].satisfies?('>= 10.11')
-      shell '/usr/local/bin/bash' if mac_os_x? && node['platform_version'].satisfies?('>= 10.11')
-    else
-      shell '/bin/bash'
-    end
+    shell '/usr/local/bin/bash'
     gid   node['omnibus']['build_user_group']
   end
   action   :create

--- a/recipes/_user.rb
+++ b/recipes/_user.rb
@@ -40,7 +40,11 @@ user node['omnibus']['build_user'] do
   supports manage_home: true
   password node['omnibus']['build_user_password']
   unless windows?
-    shell '/bin/bash'
+    if mac_os_x? && node['platform_version'].satisfies?('>= 10.11')
+      shell '/usr/local/bin/bash' if mac_os_x? && node['platform_version'].satisfies?('>= 10.11')
+    else
+      shell '/bin/bash'
+    end
     gid   node['omnibus']['build_user_group']
   end
   action   :create

--- a/spec/recipes/bash_spec.rb
+++ b/spec/recipes/bash_spec.rb
@@ -19,11 +19,6 @@ describe 'omnibus::_bash' do
       .with_install_command('make install')
   end
 
-  it 'links /bin/bash to our bash' do
-    expect(chef_run).to create_link('/bin/bash')
-      .with_to('/usr/local/bin/bash')
-  end
-
   it 'creates the .bashrc.d' do
     expect(chef_run).to create_directory('/home/omnibus/.bashrc.d')
       .with_owner('omnibus')

--- a/spec/recipes/rsync_spec.rb
+++ b/spec/recipes/rsync_spec.rb
@@ -18,9 +18,4 @@ describe 'omnibus::_rsync' do
       .with_compile_command('make -j 2')
       .with_install_command('make install')
   end
-
-  it 'links /bin/rsync to our rsync' do
-    expect(chef_run).to create_link('/bin/rsync')
-      .with_to('/usr/local/bin/rsync')
-  end
 end


### PR DESCRIPTION
cc @opscode-cookbooks/engineering-services

Most of these changes are to accommodate OS X 10.11 System Image Protection, which does not allow modifications to `/usr/bin`.  